### PR TITLE
PortfolioID in path should be marked as required

### DIFF
--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -531,7 +531,7 @@ parameters:
     name: portfolio_id
     in: path
     description: The Portfolio ID
-    required: false
+    required: true
     type: integer
   PortfolioItemID:
     name: portfolio_item_id


### PR DESCRIPTION
All Parameters used in a REST API path have to be marked as required.