### PR TITLE
Remove portfolio_id as a parameter of PortfolioItem

### DIFF
--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -604,10 +604,6 @@ definitions:
   PortfolioItem:
     type: object
     properties:
-      portfolio_id:
-        type: integer
-        title: PortfolioId
-        example: Id of the portfolio object
       favorite:
         type: boolean
         title: Favorite


### PR DESCRIPTION
Remove the portfolio_id parameter for PortfolioItem as it is no longer valid due to a HABTM relationship on the Modeling 