### PR TITLE
Added missing portfolio methods into the base_controller

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -51,9 +51,22 @@ class BaseController < ApplicationController
     render json: portfolios
   end
 
+  def list_portfolio_items
+    render json: PortfolioItem.all
+  end
+
   def fetch_portfolio_with_id
-    item = Portfolio.where(:id => params[:portfolio_id]).first
-    render json: item
+    render json: Portfolio.find_by(:id => params[:portfolio_id])
+  end
+
+  def fetch_portfolio_item_from_portfolio
+    items = Portfolio.find(params[:portfolio_id])
+                     .portfolio_items.find_by(:id => params[:portfolio_item_id])
+    render json: items
+  end
+
+  def fetch_portfolio_items_with_portfolio
+    render json: Portfolio.find(params[:portfolio_id]).portfolio_items
   end
 
   def list_progress_messages


### PR DESCRIPTION
Found some missing methods in `base_controller` for shared `users`, `admins` routes.

Tests will be added into https://github.com/ManageIQ/insights-api-service_portal/pull/12 to cover these methods.  The PR is here to help @lgalis move forward.