### PR TITLE
Add id properties back into swagger yaml as read only

### DIFF
--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -623,6 +623,9 @@ definitions:
       - name
       - description
     properties:
+      id:
+        type: string
+        readOnly: true
       name:
         type: string
         title: Name
@@ -651,6 +654,9 @@ definitions:
   PortfolioItem:
     type: object
     properties:
+      id:
+        type: string
+        readOnly: true
       favorite:
         type: boolean
         title: Favorite


### PR DESCRIPTION
Added these properties back into the Swagger YAML to fix issues with code gen for the client